### PR TITLE
Fix exception if the parsed value is not a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,8 @@
   function parse(str) {
     var matches;
 
+    if (typeof str !== "string") return null;
+
     if (matches = str.match(/^(\w+) (\d+)-(\d+)\/(\d+|\*)/)) return {
         unit: matches[1],
         first: +matches[2],

--- a/test.js
+++ b/test.js
@@ -86,5 +86,9 @@ describe('Content-range formatter', function () {
     it('should return null if parse fail', function () {
       assert.equal(contentRange.parse('blooo'), null);
     });
+
+    it('should return null if parse is not a string', function () {
+      assert.equal(contentRange.parse(null), null);
+    });
   });
 });


### PR DESCRIPTION
This would prevent errors when the argument passed to `parse` is not a `String` value.